### PR TITLE
Add self.action in the init

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -18,6 +18,7 @@ def classFactory(iface):
 class MinimalPlugin:
     def __init__(self, iface):
         self.iface = iface
+        self.action = None
 
     def initGui(self):
         self.action = QAction('Go!', self.iface.mainWindow())


### PR DESCRIPTION
Because every variables used in a class must be created in the `__init__`.
There is a warning in a IDE.